### PR TITLE
fix: use YAML array for tags in PCB assembly guide front matter

### DIFF
--- a/docs/Dev-Kit-Guides/Assembly-Guides/BC-PCB.md
+++ b/docs/Dev-Kit-Guides/Assembly-Guides/BC-PCB.md
@@ -1,6 +1,6 @@
 ---
 title: BC_PCB_Dev-Kit_Assembly_Manual
-tags: pcb
+tags: [pcb]
 ---
 
 # Project Quiver Dev-Kit BC PCB Assembly Manual

--- a/docs/Dev-Kit-Guides/Assembly-Guides/FC-PCB.md
+++ b/docs/Dev-Kit-Guides/Assembly-Guides/FC-PCB.md
@@ -1,6 +1,6 @@
 ---
 title: FC_PCB_Dev-Kit_Assembly_Manual
-tags: pcb
+tags: [pcb]
 ---
 
 # Project Quiver Dev-Kit FC PCB Assembly Manual

--- a/docs/Dev-Kit-Guides/Assembly-Guides/Main-PCB.md
+++ b/docs/Dev-Kit-Guides/Assembly-Guides/Main-PCB.md
@@ -1,6 +1,6 @@
 ---
 title: Main_PCB_Dev-Kit_Assembly_Manual
-tags: pcb
+tags: [pcb]
 ---
 
 # Project Quiver Dev-Kit Main PCB Assembly Manual


### PR DESCRIPTION
The website build is failing because Docusaurus requires `tags` in front matter to be a YAML array, not a bare string.

**Affected files:**
- `docs/Dev-Kit-Guides/Assembly-Guides/BC-PCB.md`
- `docs/Dev-Kit-Guides/Assembly-Guides/FC-PCB.md`
- `docs/Dev-Kit-Guides/Assembly-Guides/Main-PCB.md`

**Change:** `tags: pcb` → `tags: [pcb]`

**Failed run:** https://github.com/Arrow-air/website/actions/runs/24459018738/job/71467630939