### PR TITLE
fix: replace broken image refs with TODO placeholders

### DIFF
--- a/docs/Dev-Kit-Guides/Assembly-Guides/structural-assembly.md
+++ b/docs/Dev-Kit-Guides/Assembly-Guides/structural-assembly.md
@@ -745,7 +745,7 @@
 
 |Busbar Installation|
 |--|
-|![](assets/images/structural/step13_1.png)|
+|TODO: image needed (devkit busbar photo)|
   
 ---
 ### Step 14. Install BC PCB Cover
@@ -999,7 +999,7 @@
   - Use Nut 1.
   - DO NOT use Loctite Threadlocker.
 
-![](assets/images/structural/step13_1.png)  
+<!-- TODO: image needed (devkit busbar photo) -->  
 
 ### Step 14. Install Motor Arm Tubes
 - Parts needed:

--- a/docs/Dev-Kit-Guides/Manufacturing-Guide.md
+++ b/docs/Dev-Kit-Guides/Manufacturing-Guide.md
@@ -1445,8 +1445,8 @@ N/A
 
 | | 1221 & 1222 (Battery Wall Left & Right) |
 |--|--|
-| Image| ![](assets/images/1221_1222.png) |
-| CAD File|[1221 & 1222](assets/models/1221_1222.step)|
+| Image| TODO: image needed (devkit 1221 & 1222 photo) |
+| CAD File| TODO: CAD file needed (devkit 1221 & 1222) |
 ---
 ### 1311, 1312, 1313 & 1314 - Landing Gear Vertical Tubes
 - Carbon-fiber tubes, 30 mm diameter, 2 mm thickness.


### PR DESCRIPTION
Replaces broken image/model references with TODO placeholders instead of copying PT3 assets (which differ from devkit versions).

**Changes:**
- `structural-assembly.md`: `step13_1.png` → TODO (busbar installation, 2 occurrences)
- `Manufacturing-Guide.md`: `1221_1222.png` + `.step` → TODO (battery wall left & right)

This should unblock the website build. Correct devkit images can be added later.