### PR TITLE
fix: correct all broken image and model paths in devkit docs

### DIFF
--- a/docs/Dev-Kit-Guides/Assembly-Guides/structural-assembly.md
+++ b/docs/Dev-Kit-Guides/Assembly-Guides/structural-assembly.md
@@ -947,20 +947,20 @@
 - Place Insert 1 to the holes shown in the picture from outside on the top cap.
   - Use a soldering iron to place them inside the plastic.
 
-![](assets/images/structural/step11_3.png)
+<!-- TODO: image needed -->
 
 - Place the enclosure clips on the top cap as shown in the picture.
   - Screw the anchors to the main enclosure with Screw 8.
     - DO NOT use Loctite Threadlocker.
    
-![](assets/images/structural/step11_4.png)
+<!-- TODO: image needed -->
 
 - Place the top cap over the chassis.
 - Secure the enclosure hinges on the top cap and the main enclosure.
   - Use Screw 7.
   - DO NOT use Loctite Threadlocker.
 
-![](assets/images/structural/step11_5.png)
+<!-- TODO: image needed -->
 
 ### Step 12. Install Sensor Mount
 - Parts needed:

--- a/docs/Dev-Kit-Guides/Manufacturing-Guide.md
+++ b/docs/Dev-Kit-Guides/Manufacturing-Guide.md
@@ -1423,7 +1423,7 @@ N/A
 |--|--|--|--|
 |Thickness| 1 mm| 1 mm| 4 mm|
 | Image| <img src="assets/images/1111.png" alt="Alt Text" width="800"> | <img src="assets/images/1112.png" alt="Alt Text" width="800"> | <img src="assets/images/1113.png" alt="Alt Text" width="800"> |  
-| CAD File|[1111](assets/models/1111.step)| [1112](assets/models/1112.step)| [1113](assets/models/1113.step)|
+| CAD File|[1111](./Assembly-Guides/assets/models/structural/1111.step)| [1112](./Assembly-Guides/assets/models/structural/1112.step)| [1113](./Assembly-Guides/assets/models/structural/1113.step)|
 ---
 ### 1211, 1212 & 1213 - Cockpit Support Beams
 - All three are aluminum 6 series, 40x40x1 mm square tubes, laser cut, sanded.
@@ -1435,7 +1435,7 @@ N/A
 |--|--|--|
 |Length|289.2 mm|124.2 mm|
 | Image| <img src="assets/images/1211.png" alt="Alt Text" width="300"> | <img src="assets/images/1212_1213.png" alt="Alt Text" width="300"> |
-| CAD File|[1211](assets/models/1211.step)| [1212 & 1213](assets/models/1212_1213.step)|
+| CAD File|[1211](./Assembly-Guides/assets/models/structural/1211.step)| [1212 & 1213](./Assembly-Guides/assets/models/structural/1212_1213.step)|
 ---
 ### 1221 & 1222 - Battery Walls
 - Both are aluminum 6 series, 1000x30x2 mm rectangular tubes, laser cut, sanded.
@@ -1469,7 +1469,7 @@ N/A
 
 | 1331, 1332, 1333 & 1334 (Landing Gear Main Adapter) |
 |--|
-| ![](assets/images/133X.jpeg) |
+| ![](./Assembly-Guides/assets/images/structural/133X.jpeg) |
 ---
 ### 1341, 1342, 1343 & 1344 - Landing Gear Tube Joints
 - 3D printed.
@@ -1479,8 +1479,8 @@ N/A
 
 | | 1341, 1342, 1343 & 1344  (Landing Gear Tube Joint) |
 |--|--|
-| Image| ![](assets/images/134X.png) |
-| CAD File|[1221 & 1222](assets/models/134X.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/134X.png) |
+| CAD File|[1221 & 1222](./Assembly-Guides/assets/models/structural/134X.step)|
 ---
 ### 1351, 1352, 1353 & 1354 - Landing Gear Foam Wraps.
 - Pipe insulation foam, 28 mm inner diameter, 46 mm outer diameter.
@@ -1491,7 +1491,7 @@ N/A
 
 | 1351, 1352, 1353 & 1354 (Landing Gear Foam Wrap) |
 |--|
-| ![](assets/images/135X.jpg) |
+| ![](./Assembly-Guides/assets/images/structural/135X.jpg) |
 ---
 ### 1411, 1421, 1431 & 1441 - Motor Arm Foldable Connectors
 - 30 mm tube diameter version.
@@ -1500,7 +1500,7 @@ N/A
 
 | 1411, 1421, 1431 & 1441 (Motor Arm Foldable Connectors) |
 |--|
-| ![](assets/images/14X1.jpg) |
+| ![](./Assembly-Guides/assets/images/structural/14X1.jpg) |
 ---
 ### 1412, 1422, 1432 & 1442 - Motor Arms
 - Carbon-fiber tubes, 30 mm diameter, 2 mm thickness.
@@ -1517,8 +1517,8 @@ N/A
 
 | | 2111 & 2121 (Attachment Interface Spacers, Left and Right) | 2131 (Attachment Interface Spacer, Bottom) |
 |--|--|--|
-| Image| ![](assets/images/2111_2121.png) | ![](assets/images/2131.png) |
-| CAD File|[2111 & 2121](assets/models/2111_2121.step)| [2131](assets/models/2131.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2111_2121.png) | ![](./Assembly-Guides/assets/images/structural/2131.png) |
+| CAD File|[2111 & 2121](./Assembly-Guides/assets/models/structural/2111_2121.step)| [2131](./Assembly-Guides/assets/models/structural/2131.step)|
 ---
 ### 2112, 2122 & 2132 - Attachment Interfaces
 - Parts are identical, order 3 parts.
@@ -1527,7 +1527,7 @@ N/A
 
 | 2112, 2122 & 2132 (Attachment Interface) |
 |--|
-| ![](assets/images/2112_2122_2132.png) |
+| ![](./Assembly-Guides/assets/images/structural/2112_2122_2132.png) |
 ---
 ### 2211 & 2212 - Battery Sliders
 - 3D printed.
@@ -1537,8 +1537,8 @@ N/A
 
 | | 2211 & 2212  (Battery Slider) |
 |--|--|
-| Image| ![](assets/images/2211_2212.png) |
-| CAD File|[2211 & 2212](assets/models/2211_2212.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2211_2212.png) |
+| CAD File|[2211 & 2212](./Assembly-Guides/assets/models/structural/2211_2212.step)|
 ---
 ### 2311 - Main PCB Mount
 - 3D printed.
@@ -1548,8 +1548,8 @@ N/A
 
 | | 2311  (Main PCB Mount) |
 |--|--|
-| Image| ![](assets/images/2311.png) |
-| CAD File|[2211 & 2212](assets/models/2311.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2311.png) |
+| CAD File|[2211 & 2212](./Assembly-Guides/assets/models/structural/2311.step)|
 ---
 ### 2312 - Battery Connector PCB Mount
 - 3D printed.
@@ -1559,8 +1559,8 @@ N/A
 
 | | 2312  (BC PCB Mount) |
 |--|--|
-| Image| ![](assets/images/2312.png) |
-| CAD File|[2312](assets/models/2312.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2312.png) |
+| CAD File|[2312](./Assembly-Guides/assets/models/structural/2312.step)|
 ---
 ### 2313 - Battery Connector PCB Cover
 - 3D printed.
@@ -1570,8 +1570,8 @@ N/A
 
 | | 2313  (BC PCB Cover) |
 |--|--|
-| Image| ![](assets/images/2313.png) |
-| CAD File|[2313](assets/models/2313.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2313.png) |
+| CAD File|[2313](./Assembly-Guides/assets/models/structural/2313.step)|
 ---
 ### 2321 - Sensor Mount
 - 3D printed.
@@ -1581,8 +1581,8 @@ N/A
 
 | | 2321  (Sensor Mount) |
 |--|--|
-| Image| ![](assets/images/2321.png) |
-| CAD File|[2321](assets/models/2321.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2321.png) |
+| CAD File|[2321](./Assembly-Guides/assets/models/structural/2321.step)|
 ---
 ### 2331 - GNSS Mount
 - 3D printed.
@@ -1592,8 +1592,8 @@ N/A
 
 | | 2331  (GNSS Mount) |
 |--|--|
-| Image| ![](assets/images/2331.png) |
-| CAD File|[2331](assets/models/2331.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2331.png) |
+| CAD File|[2331](./Assembly-Guides/assets/models/structural/2331.step)|
 ---
 ### 2341 - PPP & Beacon Mount
 - 3D printed.
@@ -1603,8 +1603,8 @@ N/A
 
 | | 2341  (PPP & Beacon Mount) |
 |--|--|
-| Image| ![](assets/images/2341.png) |
-| CAD File|[2341](assets/models/2341.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2341.png) |
+| CAD File|[2341](./Assembly-Guides/assets/models/structural/2341.step)|
 ---
 ### 2411 - Main Enclosure
 - 3D printed.
@@ -1614,8 +1614,8 @@ N/A
 
 | | 2411  (Main Enclosure) |
 |--|--|
-| Image| ![](assets/images/2411.png) |
-| CAD File|[2411](assets/models/2411.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2411.png) |
+| CAD File|[2411](./Assembly-Guides/assets/models/structural/2411.step)|
 ---
 ### 2412 - Top Cap
 - 3D printed.
@@ -1626,9 +1626,9 @@ N/A
 ---
 | | 2412  (Top Cap) |
 |--|--|
-| Image| ![](assets/images/2412.png) |
-| Print Orientation| ![](assets/images/2412_2.png) |
-| CAD File|[2412](assets/models/2412.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/2412.png) |
+| Print Orientation| ![](./Assembly-Guides/assets/images/structural/2412_2.png) |
+| CAD File|[2412](./Assembly-Guides/assets/models/structural/2412.step)|
 ---
 ### 2421 & 2422 - Enclosure Hinges
 - Off-the-shelf component.
@@ -1638,7 +1638,7 @@ N/A
 
 | 2421 & 2422  (Enclosure Hinges) |
 |--|
-| ![](assets/images/2421_2422.png) |
+| ![](./Assembly-Guides/assets/images/structural/2421_2422.png) |
 ---
 ### 2431 & 2432 - Enclosure Latches
 - Off-the-shelf component.
@@ -1658,8 +1658,8 @@ N/A
 
 | | 3322 (Busbar Positive) | 3323 (Busbar Negative) |
 |--|--|--|
-| Image| ![](assets/images/3322.png) | ![](assets/images/3323.png) |
-| CAD File|[3322](assets/models/3322.step)| [2131](assets/models/3323.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/3322.png) | ![](./Assembly-Guides/assets/images/structural/3323.png) |
+| CAD File|[3322](./Assembly-Guides/assets/models/structural/3322.step)| [2131](./Assembly-Guides/assets/models/structural/3323.step)|
 --
 ### 3324 - BC PCB Heatsink
 - Aluminum 6 series, laser cut, sanded.
@@ -1670,8 +1670,8 @@ N/A
 
 | | 3324 (BC PCB Heatsink) |
 |--|--|
-| Image| ![](assets/images/3324.png) |
-| CAD File|[3324 - 4 mm](assets/models/3324.step) , [3324 - 5 mm](assets/models/3324_2.step)|
+| Image| ![](./Assembly-Guides/assets/images/structural/3324.png) |
+| CAD File|[3324 - 4 mm](./Assembly-Guides/assets/models/structural/3324.step) , [3324 - 5 mm](./Assembly-Guides/assets/models/structural/3324_2.step)|
 ---
 
 ### Tool List
@@ -1703,7 +1703,7 @@ N/A
 
 |Orientation|Adhesive Area|Rivet Holes|
 |--|--|--|
-|![](assets/images/step1_1.png)| ![](assets/images/step1_3.png) | ![](assets/images/step1_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step1_1.png)| ![](./Assembly-Guides/assets/images/structural/step1_3.png) | ![](./Assembly-Guides/assets/images/structural/step1_2.png) |
 ---
 
 ### Step 2. Install the Battery Walls
@@ -1718,7 +1718,7 @@ N/A
 
 |Orientation|Adhesive Area|Rivet Holes|
 |--|--|--|
-|![](assets/images/step2_1.png)| ![](assets/images/step2_3.png) | ![](assets/images/step2_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step2_1.png)| ![](./Assembly-Guides/assets/images/structural/step2_3.png) | ![](./Assembly-Guides/assets/images/structural/step2_2.png) |
 ---
 
 ### Step 3. Install the Motor Arm Connectors
@@ -1733,7 +1733,7 @@ N/A
 
 | Motor Arm Connector - Loctite Threadlocker Application|
 |---|
-| ![](assets/images/step3_3.png)|
+| ![](./Assembly-Guides/assets/images/structural/step3_3.png)|
  
 - Place the motor arm connectors on the chassis as shown in the picture.
 - Secure the motor arm connectors on the chassis.
@@ -1744,7 +1744,7 @@ N/A
  
 |Orientation|Screw Holes|
 |--|--|
-|![](assets/images/step3_1.png)| ![](assets/images/step3_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step3_1.png)| ![](./Assembly-Guides/assets/images/structural/step3_2.png) |
 ---
 ### Step 4. Install the Lower Plate
 - Parts needed:
@@ -1757,7 +1757,7 @@ N/A
 
 |Orientation|Adhesive Area|Rivet Holes|
 |--|--|--|
-|![](assets/images/step4_1.png)| ![](assets/images/step4_3.png) | ![](assets/images/step4_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step4_1.png)| ![](./Assembly-Guides/assets/images/structural/step4_3.png) | ![](./Assembly-Guides/assets/images/structural/step4_2.png) |
 ---
 ### Step 5. Install the Upper Plate
 - Parts needed:
@@ -1776,7 +1776,7 @@ N/A
 
 |Orientation|Adhesive Area|Rivet Holes|
 |--|--|--|
-|![](assets/images/step5_1.png)| ![](assets/images/step5_3.png) | ![](assets/images/step5_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step5_1.png)| ![](./Assembly-Guides/assets/images/structural/step5_3.png) | ![](./Assembly-Guides/assets/images/structural/step5_2.png) |
 ---
 ### Step 6. Install the Main PCB Mount
 - Parts needed:
@@ -1789,20 +1789,20 @@ N/A
 
 | Top Insert Locations|
 |---|
-| ![](assets/images/step6_1.png)|
+| ![](./Assembly-Guides/assets/images/structural/step6_1.png)|
 
 - Install 5x Insert 4 into the bottom face of the Main PCB Mount (2311) as shown in the picture.
 
 | Bottom Insert Locations|
 |---|
-| ![](assets/images/step6_2.png)|
+| ![](./Assembly-Guides/assets/images/structural/step6_2.png)|
 
 - Install 5x Vibration Mount into the designated holes on the Upper Plate (1111).
 - Orientation: Ensure the longer side of the rubber dampener (3 mm section) is facing upwards, towards where the 3D-printed holder will sit.
 
 | Vibration Mount Locations| Vibration Mount Insertion |
 |---|---|
-| ![](assets/images/step6_5.png)| ![](assets/images/step6_3.png)|
+| ![](./Assembly-Guides/assets/images/structural/step6_5.png)| ![](./Assembly-Guides/assets/images/structural/step6_3.png)|
 
 - Apply a small amount of Loctite Threadlocker Blue to the threads of the 5x Screw 11 (M3x6) flat head screws.
 - Align the 3D-printed mount over the rubber dampeners.
@@ -1811,7 +1811,7 @@ N/A
 
 | Vibration Mount Compression|
 |---|
-| ![](assets/images/step6_4.png)|
+| ![](./Assembly-Guides/assets/images/structural/step6_4.png)|
 ---
 ### Step 7. Install the Battery Connector PCB Mount
 - Parts needed:
@@ -1825,13 +1825,13 @@ N/A
 
 |Top|Bottom|
 |--|--|
-|![](assets/images/step7_1.png)| ![](assets/images/step7_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step7_1.png)| ![](./Assembly-Guides/assets/images/structural/step7_2.png) |
 
 - Place the Battery Connector PCB mount over the mid plate.
   - Secure it with 3x Screw 5 in total from below the mid plate on the holes below.
   - Use Washer 1 for the holes.
 
-![](assets/images/step7_3.png)
+![](./Assembly-Guides/assets/images/structural/step7_3.png)
 ---
 ### Step 8. Install the Battery Sliders
 - Parts needed:
@@ -1843,7 +1843,7 @@ N/A
 - Place Insert 2 to the holes shown in the picture on both of the battery slides.
   - Use a soldering iron to place them inside the plastic.
 
-![](assets/images/step8_1.png)
+![](./Assembly-Guides/assets/images/structural/step8_1.png)
 
 - Place the battery sliders inside the battery compartment.
   - Be careful about the orientation of the angled end, they should point where the cutouts on the plates are.
@@ -1852,7 +1852,7 @@ N/A
 
 |Orientation|Installation Holes|
 |--|--|
-|![](assets/images/step8_2.png)| ![](assets/images/step8_3.png) |
+|![](./Assembly-Guides/assets/images/structural/step8_2.png)| ![](./Assembly-Guides/assets/images/structural/step8_3.png) |
 ---
 ### Step 9. Install the Landing Gear
 - Parts needed:
@@ -1873,7 +1873,7 @@ N/A
 
 |Orientation|Installation Holes|
 |--|--|
-|![](assets/images/step9_1.png)| ![](assets/images/step9_2.png) |
+|![](./Assembly-Guides/assets/images/structural/step9_1.png)| ![](./Assembly-Guides/assets/images/structural/step9_2.png) |
 
 - Insert the vertical landing gear tubes inside landing gear main adapters.
   - Make sure the tubes are inserted all the way.
@@ -1882,7 +1882,7 @@ N/A
 
 |Landing Gear Adapter|
 |---|
-|![](assets/images/step9_3.png)|
+|![](./Assembly-Guides/assets/images/structural/step9_3.png)|
 
 - Make sure the chassis stands level on the ground.
   -  If not, measure and equalize the tube lengths.
@@ -1895,7 +1895,7 @@ N/A
 
 |Positioning|Installation Holes|Correct Final Appearance |
 |--|--|--|
-|![](assets/images/step9_5.png)| ![](assets/images/step9_4.png) | ![](assets/images/step9_6.png) |
+|![](./Assembly-Guides/assets/images/structural/step9_5.png)| ![](./Assembly-Guides/assets/images/structural/step9_4.png) | ![](./Assembly-Guides/assets/images/structural/step9_6.png) |
 
 
 ### Step 10. Install Sensor Mount
@@ -1914,7 +1914,7 @@ N/A
 
 |Insert 1 (6.4 mm) Locations|
 |---|
-|![](assets/images/step10_1.png)|
+|![](./Assembly-Guides/assets/images/structural/step10_1.png)|
 
 - Place Insert 4 to the holes shown in the picture.
   - Use a soldering iron to place them inside the plastic.
@@ -1922,7 +1922,7 @@ N/A
 
 |Insert 4 (3.8 mm) Locations|
 |---|
-|![](assets/images/step10_2.png)|
+|![](./Assembly-Guides/assets/images/structural/step10_2.png)|
 
 - Secure the sensor mount on the lower plate.
   - Screw head stays inside the mount.
@@ -1933,7 +1933,7 @@ N/A
 
 |Lower Plate Fasteners|
 |---|
-|![](assets/images/step10_3.png)|
+|![](./Assembly-Guides/assets/images/structural/step10_3.png)|
 
 - Secure the sensor mount on the battery walls.
   - Use Screw 5.
@@ -1942,7 +1942,7 @@ N/A
 
 |Battery Wall Fasteners|
 |---|
-|![](assets/images/step10_4.png)|
+|![](./Assembly-Guides/assets/images/structural/step10_4.png)|
 ---
 
 ### Step 11. Insert Grommets
@@ -1954,13 +1954,13 @@ N/A
 
 |Grommet 1 Location|
 |---|
-|![](assets/images/step11_1.png)|
+|![](./Assembly-Guides/assets/images/structural/step11_1.png)|
 
 - Insert 12x Grommet 2 into the holes on the sides of upper, mid and lower plates on each side.
 
 |Grommet 2 Location|
 |---|
-|![](assets/images/step11_2.png)|
+|![](./Assembly-Guides/assets/images/structural/step11_2.png)|
 
 ### Step 12. Install PCBs & Onboard Components
 - Parts needed:
@@ -1988,7 +1988,7 @@ N/A
 
 |BC PCB & Bolt Locations|
 |---|
-|![](assets/images/step12_1.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_1.png)|
 
 - Place the Main PCB as shown in the picture.
   - See the warning before installation.
@@ -2003,7 +2003,7 @@ N/A
 
 |Main PCB & Bolt Locations| Through-hole Pin Trim|
 |---|---|
-|![](assets/images/step12_2.png)|![](assets/images/step12_12.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_2.png)|![](./Assembly-Guides/assets/images/structural/step12_12.png)|
 
 - Place Ethernet Switches on the Main PCB slots, as shown in the picture.
   - Securely plug the connectors.
@@ -2012,7 +2012,7 @@ N/A
  
 |Ethernet Switch Locations|
 |--|
-|![](assets/images/step12_8.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_8.png)|
 
 - Place the Flight Controller on the FC PCB.
   - Pay extreme attention to the orientation shown in the images.
@@ -2022,7 +2022,7 @@ N/A
  
 |FC & FC PCB Orientation ||
 |--|--|
-|![](assets/images/step12_4.png)|![](assets/images/step12_3.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_4.png)|![](./Assembly-Guides/assets/images/structural/step12_3.png)|
 
 - Place F9P NEO RTK GNSS on the GNSS Mount.
   - The direction of the arrow on the RTK GNSS should match the one provided in the picture.
@@ -2031,7 +2031,7 @@ N/A
 
 |GNSS Orientation|
 |--|
-|![](assets/images/step12_10.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_10.png)|
 
 - Place the FC PCB into the GNSS Mount.
 - Place the FC PCB and GNSS Mount on the Main PCB.
@@ -2043,7 +2043,7 @@ N/A
 
 |Flight Controller Orientation | GNSS Mount Orientation | Installation Holes |
 |--|--|--|
-|![](assets/images/step12_5.png)| ![](assets/images/step12_6.png) | ![](assets/images/step12_7.png) 
+|![](./Assembly-Guides/assets/images/structural/step12_5.png)| ![](./Assembly-Guides/assets/images/structural/step12_6.png) | ![](./Assembly-Guides/assets/images/structural/step12_7.png) 
 
 - Place RPI 5 on the Main PCB slot, as shown in the picture.
   - Securely plug the connectors.
@@ -2051,7 +2051,7 @@ N/A
  
 |RPI 5 Installation|
 |--|
-|![](assets/images/step12_9.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_9.png)|
 
 - Place Mateksys GNSS on the Main PCB slot, as shown in the picture.
   - Securely plug the connectors.
@@ -2060,7 +2060,7 @@ N/A
  
 |Mateksys GNSS Installation|
 |--|
-|![](assets/images/step12_11.png)|
+|![](./Assembly-Guides/assets/images/structural/step12_11.png)|
 
 
 ---
@@ -2077,7 +2077,7 @@ N/A
 
 |Busbar Installation|
 |--|
-|![](assets/images/step13_1.png)|
+|<!-- TODO: image needed -->|
   
 ---
 ### Step 14. Install BC PCB Cover
@@ -2096,7 +2096,7 @@ N/A
 
 | Insert 4 Locations | Screw Locations |
 |--|--|
-|![](assets/images/step14_1.png)|![](assets/images/step14_2.png)|
+|![](./Assembly-Guides/assets/images/structural/step14_1.png)|![](./Assembly-Guides/assets/images/structural/step14_2.png)|
 
 ---
 ### Step 15. Install Attachment Interfaces
@@ -2117,7 +2117,7 @@ N/A
 
 |Positioning|Installation Holes| Notch Orientation|
 |--|--|--|
-|![](assets/images/step15_1.png)| ![](assets/images/step15_2.png) | ![](assets/images/step15_3.png) |
+|![](./Assembly-Guides/assets/images/structural/step15_1.png)| ![](./Assembly-Guides/assets/images/structural/step15_2.png) | ![](./Assembly-Guides/assets/images/structural/step15_3.png) |
 
 - Place and secure the bottom attachment interface and the spacer as shown in the pictures.
   - Make sure the rectangular holes are aligned with the holes on the battery walls.
@@ -2128,7 +2128,7 @@ N/A
 
 |Positioning, Cable & Notch Orientation|Installation Holes|
 |--|--|
-|![](assets/images/step15_4.png)| ![](assets/images/step15_5.png) |
+|![](./Assembly-Guides/assets/images/structural/step15_4.png)| ![](./Assembly-Guides/assets/images/structural/step15_5.png) |
 
 ---
 ### Step 16. Install Radar Sensors
@@ -2144,7 +2144,7 @@ N/A
 
 |Obstacle Avoidance Installation|
 |--|
-|![](assets/images/step16_1.png)|
+|![](./Assembly-Guides/assets/images/structural/step16_1.png)|
  
 - Secure Nanoradar NRA15 in front-bottom corner of the drone, as shown in the image.
   - Use 4x Screw 11.
@@ -2153,7 +2153,7 @@ N/A
 
 |Radar Altimeter Installation|
 |--|
-|![](assets/images/step16_2.png)|
+|![](./Assembly-Guides/assets/images/structural/step16_2.png)|
 
 ---
 ### Step 17. Install Camera
@@ -2172,7 +2172,7 @@ N/A
 
 | Camera Installation Holes | Camera Orientation |
 |--|--|
-|![](assets/images/step17_1.png)|![](assets/images/step17_2.png)|
+|![](./Assembly-Guides/assets/images/structural/step17_1.png)|![](./Assembly-Guides/assets/images/structural/step17_2.png)|
 
 ---
 ### Step 18. Install Motor Arm Tubes & Motors
@@ -2192,7 +2192,7 @@ N/A
 
 |Motor Arm Tube Hole Drilling Layout|
 |--|
-|![](assets/images/step18_1.jpeg)|
+|![](./Assembly-Guides/assets/images/structural/step18_1.jpeg)|
 
 - Slide a tube inside each motor tube clamp.
   - Orient the tube so that the motor is installed on the end with the shorter hole-to-end distance.
@@ -2208,7 +2208,7 @@ N/A
 
 |Motor Installation|
 |--|
-|![](assets/images/step18_2.jpeg)|
+|![](./Assembly-Guides/assets/images/structural/step18_2.png)|
 
 - Install the motor arms on the motor arm connectors.
   - Mind the motor spin directions. Use **Ardupilot Quad X** motor layout. See the image for reference. The front of the drone is where the radar sensors are.
@@ -2224,7 +2224,7 @@ N/A
 
 |Motor Arm Installation| Motor Cable Routing|
 |--|--|
-|![](assets/images/step18_3.jpeg)|![](assets/images/step18_4.jpeg)|
+|![](./Assembly-Guides/assets/images/structural/step18_3.png)|![](./Assembly-Guides/assets/images/structural/step18_4.png)|
  
 - Set the LED colors at each end of the motors.
   - LEDs on the left side motors (Motors 2 & 3, C & D) should be **RED**.
@@ -2233,7 +2233,7 @@ N/A
 
 |Adjusting LED Color Instructions|
 |--|
-|![](assets/images/step18_5.jpeg)|
+|![](./Assembly-Guides/assets/images/structural/step18_5.png)|
 
 
 
@@ -2265,7 +2265,7 @@ N/A
 - Place Insert 1 to the holes shown in the picture from outside on the main enclosure.
   - Use a soldering iron to place them inside the plastic.
 
-![](assets/images/step11_1.png) 
+![](./Assembly-Guides/assets/images/structural/step11_1.png) 
 
 - Place the enclosure anchors and the main enclosure over the chassis.
   - The anchors will fit on the circular cutouts on the battery walls.
@@ -2274,25 +2274,25 @@ N/A
     - Use Washer 1.
     - DO NOT use Loctite Threadlocker.
 
-![](assets/images/step11_2.png) 
+![](./Assembly-Guides/assets/images/structural/step11_2.png) 
 
 - Place Insert 1 to the holes shown in the picture from outside on the top cap.
   - Use a soldering iron to place them inside the plastic.
 
-![](assets/images/step11_3.png)
+<!-- TODO: image needed -->
 
 - Place the enclosure clips on the top cap as shown in the picture.
   - Screw the anchors to the main enclosure with Screw 8.
     - DO NOT use Loctite Threadlocker.
    
-![](assets/images/step11_4.png)
+<!-- TODO: image needed -->
 
 - Place the top cap over the chassis.
 - Secure the enclosure hinges on the top cap and the main enclosure.
   - Use Screw 7.
   - DO NOT use Loctite Threadlocker.
 
-![](assets/images/step11_5.png)
+<!-- TODO: image needed -->
 
 ### Step 12. Install Sensor Mount
 - Parts needed:
@@ -2305,7 +2305,7 @@ N/A
 - Place Insert 1 to the holes shown in the picture.
   - Use a soldering iron to place them inside the plastic.
 
-![](assets/images/step12_1.png)
+![](./Assembly-Guides/assets/images/structural/step12_1.png)
 
 - Secure the altitude sensor mount on the lower plate.
   - Screw head stays inside the mount.
@@ -2314,7 +2314,7 @@ N/A
   - Use Nut 1.
   - DO NOT use Loctite Threadlocker.
 
-![](assets/images/step12_2.png)  
+![](./Assembly-Guides/assets/images/structural/step12_2.png)  
 
 ### Step 13. Install Camera Mount
 - Parts needed:
@@ -2331,7 +2331,7 @@ N/A
   - Use Nut 1.
   - DO NOT use Loctite Threadlocker.
 
-![](assets/images/step13_1.png)  
+<!-- TODO: image needed -->  
 
 ### Step 14. Install Motor Arm Tubes
 - Parts needed:
@@ -2346,13 +2346,13 @@ N/A
   - Tighten the clamps with the screws provided in the motor arm connector package.
   - Use Loctite Threadlocker Blue to secure the screws.
 
-![](assets/images/step14_1.png)
+![](./Assembly-Guides/assets/images/structural/step14_1.png)
 
 - Drill the tubes with 3 mm drill bit on the marked holes.
   - Use Screw 6.
   - Use Washer 1 on each side.
   - Use Nut 1.
  
-![](assets/images/step14_2.png)
+![](./Assembly-Guides/assets/images/structural/step14_2.png)
 
 -----


### PR DESCRIPTION
Comprehensive fix for all broken image/model references that were failing the website build.

**Manufacturing-Guide.md:**
- ~85 image refs: `assets/images/X` → `./Assembly-Guides/assets/images/structural/X`
- ~20 model refs: `assets/models/X` → `./Assembly-Guides/assets/models/structural/X`
- Fixed step18_2-5 wrong extension: `.jpeg` → `.png`
- step11_3-5 and step13_1: replaced with TODO (genuinely missing)

**structural-assembly.md:**
- step11_3-5: replaced with TODO (genuinely missing)

**Verification:** Scanned all markdown files in `docs/` — zero broken local image refs remaining.

Supersedes the partial fix in #198.