### PR TITLE
Fix archived SDK guide image path

### DIFF
--- a/docs/Dev-Kit-Guides/Archive/Quiver-SDK-Developer-Guide.md
+++ b/docs/Dev-Kit-Guides/Archive/Quiver-SDK-Developer-Guide.md
@@ -19,7 +19,7 @@ The Quiver SDK is a Python-based development toolkit that enables developers to 
 The Quiver system architecture centers around a companion computer (Raspberry Pi) that acts as the intelligent bridge between the flight controller, payload devices, and the cloud-based Quiver Hub. The companion computer connects to Quiver Hub over wireless/cellular internet for command and control, while locally managing three payload ports (C1, C2, C3) through an integrated network switch that provides both Ethernet and CAN bus connectivity.
 
 **Network Topology:**  
-![alt text](<Images/Quiver Payload Network.png>)
+![Quiver Payload Network](<../Images/Quiver Payload Network.png>)
 **Connection Details:**
 
 - **Wireless/Internet**: Companion ↔ Quiver Hub (HTTPS REST API, WebSocket telemetry)  


### PR DESCRIPTION
## Summary\n- fix archived Quiver SDK guide image path to point at the shared Dev-Kit-Guides/Images folder\n- avoids Docusaurus staging deploy failure on unresolved local image\n\n## Verification\n- local scan found 0 unresolved markdown image refs under docs\n- website Docusaurus build completed successfully after applying this imported-docs fix\n