### PR TITLE
docs: fix HAR-0014 bottom payload signal label (FMU_CH1, not FMU_CH7)

### DIFF
--- a/docs/Manufacturing/Harness-Manufacturing-Guide.mdx
+++ b/docs/Manufacturing/Harness-Manufacturing-Guide.mdx
@@ -584,7 +584,7 @@ Build HAR-0014 from the 10-conductor jacketed cable and short Molex-terminated l
 | Orange | **Pin 2** | 10 | 12V_PL |
 | White | **Pin 3** | 9 | CAN2_L |
 | Gray | **Pin 4** | 11 | CAN2_H |
-| Blue | **Pin 5** | 12 | FMU_CH7 |
+| Blue | **Pin 5** | 12 | FMU_CH1 |
 | Red | **Pin 6** | 2 and 4 | 12VSW |
 
 | Cable Color | From: 1704857 | To: 204523-1201 | Function / Signal |


### PR DESCRIPTION
## Summary
- HAR-0014 (bottom payload harness, Main PCB J31/J39 → bottom attachment interface) labeled Phoenix 1704859 pin 5 as **FMU_CH7** — that's the side-payload signal (HAR-0012/0013 → J29/J30). J31 pin 5 is **FMU_CH1**.
- Label-only fix; pin-to-pin wire routing in the table is unchanged, so already-built harnesses are unaffected.

## Evidence
- Main PCB layout (`Quiver_PT3_Main_PCB.kicad_pcb`): J31 pad 5 → net `/FMU_CH1`; J29 pad 5 → `/FMU_CH7`; J30 pad 5 → `/FMU_CH8`
- Main PCB information note (`0007-Main-PCB/information_note.md`): "Attachment Interface Payload Connector (bottom payload) — J31 … FMU_CH1 aux signal"; J29 = Side_1 (FMU_CH7), J30 = Side_2 (FMU_CH8)
- Attachment Interface PCB README (`0003-Attachment-Interface-PCB/README.md`): pogo interface carries FMU_CH1

Caught while wiring a granular spreader to the bottom interface (see #233).
