### PR TITLE
docs: remove dead Pixhawk log links from PT1 flight test reports

### DIFF
--- a/.link-checker.config.json
+++ b/.link-checker.config.json
@@ -4,10 +4,7 @@
       "pattern": "^https?://"
     },
     {
-      "pattern": "\\.([bB][iI][nN]|dxf|step|stl|zip)$"
-    },
-    {
-      "pattern": "^\\./assets/[0-9]+/logs/$"
+      "pattern": "\\.(bin|dxf|step|stl|zip)$"
     },
     {
       "pattern": "^\\./assets/readme$"

--- a/.link-checker.config.json
+++ b/.link-checker.config.json
@@ -4,7 +4,10 @@
       "pattern": "^https?://"
     },
     {
-      "pattern": "\\.(bin|dxf|step|stl|zip)$"
+      "pattern": "\\.([bB][iI][nN]|dxf|step|stl|zip)$"
+    },
+    {
+      "pattern": "^\\./assets/[0-9]+/logs/$"
     },
     {
       "pattern": "^\\./assets/readme$"

--- a/flight-test/PT1/001.md
+++ b/flight-test/PT1/001.md
@@ -104,7 +104,7 @@ This flight will be for the purpose of testing the radar altimeter, battery endu
 - Continue testing with radar altimeter
 
 #### Pixhawk Logs
-[Log #75](./assets/001/logs/00000075.BIN)
+Log #75 (`00000075.BIN` — not included in the repository)
 
 #### Voltage Reading
 - 56.26 (85% SOC)
@@ -132,7 +132,7 @@ This flight will be for the purpose of testing the radar altimeter, battery endu
 - Review logs to evaluate possible improvements for the harmonic notch filter. Consider switching from one filter to three.
 
 #### Pixhawk Logs
-[Log #76](./assets/001/logs/00000076.BIN)
+Log #76 (`00000076.BIN` — not included in the repository)
 
 #### Voltage Reading
 - 53.93 (71% SOC)
@@ -155,7 +155,7 @@ This flight will be for the purpose of testing the radar altimeter, battery endu
 - Consider adjusting the threshold voltages in Ardupilot to better match the battery capacity
 
 #### Pixhawk Logs
-[Logs #77-80](./assets/001/logs/)
+Logs #77-80 (not included in the repository)
 
 
 **Leg 4**
@@ -192,7 +192,7 @@ This flight will be for the purpose of testing the radar altimeter, battery endu
 - Log #86 has the best data for MAGFit. We gave all pitch and roll inputs at 45 degree offsets.
 - Log #87 has a flight with the offsets generated from previous flight
 - Log #88 has a flight with the offsets generated from flight #86, but using DCM attitude instead of EKF
-[Logs Here](./assets/001/logs/)
+Logs not included in the repository.
 
 #### Voltage Reading
 - Misc, battery swapped.

--- a/flight-test/PT1/002.md
+++ b/flight-test/PT1/002.md
@@ -110,7 +110,7 @@ Anything missing on the aircraft, anything that doesn't feel right
 - Review radar altimeter parameters.
 
 #### Pixhawk Logs
-[Log #89](./assets/002/logs/00000089.BIN)
+Log #89 (`00000089.BIN` — not included in the repository)
 
 #### Voltage Reading
 - 54.8V after flight
@@ -140,7 +140,7 @@ Anything missing on the aircraft, anything that doesn't feel right
 - Use data from this flight in MAGFit to improve compass calibration.
 
 #### Pixhawk Logs
-[Log #90](./assets/002/logs/00000090.BIN)
+Log #90 (`00000090.BIN` — not included in the repository)
 
 #### Voltage Reading
 - 54.17V
@@ -170,5 +170,5 @@ The MAGFit tool suggested that we had the compass orientation set incorrectly an
 - Consider a different rangefinder for future hardware.
 
 #### Pixhawk Logs
-[Log #91](./assets/002/logs/00000091.BIN)
-[Log #92](./assets/002/logs/00000092.BIN)
+Log #91 (`00000091.BIN` — not included in the repository)
+Log #92 (`00000092.BIN` — not included in the repository)

--- a/flight-test/PT1/003.md
+++ b/flight-test/PT1/003.md
@@ -110,7 +110,7 @@ Anything missing on the aircraft, anything that doesn't feel right
 - Once airworthy, extensively test the new gains.
 
 #### Pixhawk Logs
-[Log #93](./assets/003/logs/00000093.BIN)
+Log #93 (`00000093.BIN` — not included in the repository)
 
 #### Voltage Reading
 - 50.8V (39% SOC) after flight


### PR DESCRIPTION
## Summary
The **Markdown Broken Link Checker** job has failed on every PR since the flight-test archive landed on main: `flight-test/PT1/001–003.md` link Pixhawk DataFlash logs (`./assets/NNN/logs/00000075.BIN` etc.) that were never committed to main, so the links 404 for readers too.

Per discussion, rather than teaching the checker to ignore them, this removes the dead links. The log numbers are kept as plain text (marked *not included in the repository*) since they map each flight leg to its specific log.

Net diff vs main: 3 files, 9 lines — `.link-checker.config.json` is untouched (an interim ignore-pattern commit is reverted within the branch; squash-merge recommended).

## Verification
Ran `make md-test-links` locally with the same image CI uses (`ghcr.io/tcort/markdown-link-check:3.10`): **exit 0** (was 8 dead links across 3 files).

Note: CI on this PR won't run until the ongoing GitHub Actions outage is resolved; a watcher will retrigger it then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)